### PR TITLE
Debug system scripts and crs file

### DIFF
--- a/src/dropbox-handler.js
+++ b/src/dropbox-handler.js
@@ -13,6 +13,7 @@ class DropboxHandler {
     this.appKey = config.dropbox.appKey;
     this.appSecret = config.dropbox.appSecret;
     this.webhookSecret = config.dropbox.webhookSecret;
+    this.audioFolderPath = config.dropbox.folderPath || '/Recordings';
     this.pdfFolderPath = config.dropbox.pdfFolderPath;
     this.recentlyProcessedFiles = new Set();
   }
@@ -101,6 +102,25 @@ class DropboxHandler {
     } catch (error) {
       logger.error('Error verifying webhook signature:', error);
       return false;
+    }
+  }
+
+  // List all files and folders from a given path (default root)
+  async listFiles(folderPath = '') {
+    try {
+      logger.info(`Listing all entries from Dropbox path: ${folderPath || '/'} `);
+      const response = await this.makeAuthenticatedRequest({
+        method: 'POST',
+        url: 'https://api.dropboxapi.com/2/files/list_folder',
+        data: {
+          path: folderPath,
+          recursive: false
+        }
+      });
+      return response.data.entries || [];
+    } catch (error) {
+      logger.error('Failed to list entries from Dropbox:', error.response?.data || error.message);
+      throw error;
     }
   }
 


### PR DESCRIPTION
Add missing `audioFolderPath` property and `listFiles` method to `DropboxHandler` to fix crashing debug scripts.

The debug scripts in `scripts/` were failing because they tried to access `dropboxHandler.audioFolderPath` and call `dropboxHandler.listFiles()`, neither of which existed. This PR implements these missing components, allowing the debug scripts to run correctly and provide insights into the Dropbox folder structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-5629d6fb-6938-44a7-9197-2b02a1ef95b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5629d6fb-6938-44a7-9197-2b02a1ef95b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>